### PR TITLE
Make the Dockerfile compatible with Heroku

### DIFF
--- a/.github/workflows/heroku.yaml
+++ b/.github/workflows/heroku.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Deploy on Heroku
         uses: akhileshns/heroku-deploy@v3.12.12 # This is the action
         with:
-          heroku_api_key: ${{secrets.HEROKU_KEY}}
-          heroku_app_name: "pruebaspring1234"
-          heroku_email: "prubioam@zubirimanteo.com"
+          heroku_api_key: ${{secrets.HEROKU_API_KEY}}
+          heroku_app_name: ${{secrets.HEROKU_APP_NAME}}
+          heroku_email: ${{secrets.HEROKU_EMAIL}}
           usedocker: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM adoptopenjdk/openjdk13:jre-13.0.2_8-alpine
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar
 COPY ./datos.txt datos.txt
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENTRYPOINT ["sh", "-c", "java -jar app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM adoptopenjdk/openjdk13:jre-13.0.2_8-alpine
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar
 COPY ./datos.txt datos.txt
-ENTRYPOINT java -jar app.jar --server.port=$PORT
+ENTRYPOINT java -Dserver.port=$PORT -jar app.jar 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM adoptopenjdk/openjdk13:jre-13.0.2_8-alpine
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar
 COPY ./datos.txt datos.txt
-ENTRYPOINT ["sh", "-c", "java -jar app.jar"]
+ENTRYPOINT ["sh", "-c", "java -jar app.jar --server.port=$PORT"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM adoptopenjdk/openjdk13:jre-13.0.2_8-alpine
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar
 COPY ./datos.txt datos.txt
-ENTRYPOINT ["java","-jar","app.jar", "--server.port="$PORT]
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@ FROM adoptopenjdk/openjdk13:jre-13.0.2_8-alpine
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar
 COPY ./datos.txt datos.txt
-ENTRYPOINT java -Dserver.port=$PORT -jar app.jar 
+COPY ./entrypoint.sh entrypoint.sh
+ENTRYPOINT ["/bin/sh", "-c", "./entrypoint.sh"] 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM adoptopenjdk/openjdk13:jre-13.0.2_8-alpine
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} app.jar
 COPY ./datos.txt datos.txt
-ENTRYPOINT ["sh", "-c", "java -jar app.jar --server.port=$PORT"]
+ENTRYPOINT java -jar app.jar --server.port=$PORT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,2 @@
+#! /bin/sh
+java -Dserver.port=$PORT -jar app.jar 


### PR DESCRIPTION
This pull request makes our Dockerfile compatible with Heroku. Things that have changed:

- Pass the server's port number as a Java system property: https://devcenter.heroku.com/articles/setting-the-http-port-for-java-applications#spring-boot
- Use a shell script in the entrypoint, because otherwise the environment variables are not correctly processed, as stated [here](https://docs.docker.com/engine/reference/builder/#entrypoint): "Unlike the shell form, the exec form does not invoke a command shell. This means that normal shell processing does not happen. For example, ENTRYPOINT [ "echo", "$HOME" ] will not do variable substitution on $HOME. If you want shell processing then either use the shell form or execute a shell directly, for example: ENTRYPOINT [ "sh", "-c", "echo $HOME" ]".
- [Extra, not needed] Use repository secrets to store Heroku's app name and email variables.

PS: Please, do not use the "Merge" button to accept the PR, make use of the "Squash and merge" option. Otherwise, all my 7 commits will be added to the history 😉 